### PR TITLE
Fix dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "fomantic-ui": "^2.8.8",
     "next": "12.1.5",
-    "node-sonycam-example-socketio": "^0.0.6",
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "react-input-slider": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "18.0.0",
     "react-input-slider": "^6.0.1",
     "semantic-ui-react": "^2.1.2",
+    "node-sonycam": "0.0.6",
     "socket.io": "^4.5.0",
     "socket.io-client": "^4.5.0"
   },


### PR DESCRIPTION
Remove node-sonycam-example-socketio from package.json

Can't install as `node-sonycam-example-socketio` doesn't exist